### PR TITLE
Mark mod as 1.19 compatible

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,7 +25,7 @@
 
   "depends": {
     "fabricloader": ">=0.12.12",
-    "minecraft": "1.19",
+    "minecraft": ">=1.19",
     "java": ">=17"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,10 +25,7 @@
 
   "depends": {
     "fabricloader": ">=0.12.12",
-    "minecraft": "1.18.x",
+    "minecraft": "1.19",
     "java": ">=17"
-  },
-  "suggests": {
-    "another-mod": "*"
   }
 }


### PR DESCRIPTION
No other actions are needed to make this compatible with 1.19

Also i removed the `suggests: another-mod` entry because its useless and is a example by the fabric-example-mod